### PR TITLE
Amend confusing readme instructions for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ A lightweight Neovim plugin to manage session based on current working directory
     opts = {
         show_notifications = true, -- Enable or disable notifications (default: true)
     }
-    config = function()
-        require('season')
-    end
 }
 ```
 


### PR DESCRIPTION
Specifying opts will implicitly call setup for season.

Alternatively, this also makes more sense.

```lua
config = function(_, opts)
  require('season').setup(opts)
end
```